### PR TITLE
DEV-1188: Add cache registry as standalone component - Convert tool-m…

### DIFF
--- a/charts/kubiya-runner/Chart.yaml
+++ b/charts/kubiya-runner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubiya-runner
 description: A Helm chart for Kubiya Runner deployment
 type: application
-version: 0.6.75
-appVersion: "0.6.75"
+version: 0.7.0
+appVersion: "0.7.0"
 kubeVersion: ">=1.19.0-0" 
 home: https://kubiya.ai
 icon: https://raw.githubusercontent.com/kubiyabot/helm-charts/main/charts/kubiya-runner/icon.png

--- a/charts/kubiya-runner/docs/cache-registry.md
+++ b/charts/kubiya-runner/docs/cache-registry.md
@@ -1,0 +1,136 @@
+# Cache Registry Component
+
+The Cache Registry is a Docker registry component that provides image caching functionality for the Kubiya Tool Manager. It stores and serves Docker images locally within the Kubernetes cluster to improve performance and reduce external dependencies.
+
+## Overview
+
+The Cache Registry component consists of four Kubernetes resources:
+
+1. **PersistentVolume (PV)**: `docker-registry-pv` - Provides persistent storage for registry data
+2. **PersistentVolumeClaim (PVC)**: `docker-registry-pvc` - Claims storage from the PV
+3. **Deployment**: `cache-registry` - Runs the Docker registry container
+4. **Service**: `cache-registry-svc` - Exposes the registry within the cluster
+
+## Configuration
+
+The cache registry is configured through the `cacheRegistry` section in your values.yaml:
+
+```yaml
+cacheRegistry:
+  enabled: true  # Set to false to disable the cache registry
+  pv:
+    name: "docker-registry-pv"
+    size: "20Gi"
+    hostPath: "/var/lib/registry"
+  pvc:
+    name: "docker-registry-pvc"
+    size: "20Gi"
+  deployment:
+    name: "cache-registry"
+    replicas: 1
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+  service:
+    name: "cache-registry-svc"
+    port: 443
+    targetPort: 5000
+```
+
+## Storage Options
+
+### HostPath (Default)
+Uses local node storage. Suitable for development and single-node clusters:
+```yaml
+pv:
+  hostPath: "/var/lib/registry"
+```
+
+### Dynamic Provisioning
+Uses a StorageClass for dynamic volume provisioning:
+```yaml
+pv:
+  storageClass: "fast-ssd"
+pvc:
+  storageClass: "fast-ssd"
+```
+
+### NFS
+Uses Network File System for shared storage:
+```yaml
+pv:
+  volumeSource:
+    nfs:
+      server: "nfs-server.example.com"
+      path: "/path/to/registry"
+```
+
+## Security
+
+The registry is configured with TLS encryption using certificates from the `registry-tls-secret` Kubernetes secret. This secret must be created separately and contain:
+
+- `tls.crt`: TLS certificate
+- `tls.key`: TLS private key
+
+## Environment Variables
+
+The cache registry is automatically configured to work with the Tool Manager through these environment variables:
+
+- `KUBIYA_IMAGE_REGISTRY_ADDRESS`: Points to the cache registry service
+- Registry certificates are mounted at `/etc/docker/certs.d/cache-registry-svc.kubiya`
+
+## Health Checks
+
+The deployment includes both liveness and readiness probes:
+- **Endpoint**: `/v2/` (Docker Registry API v2)
+- **Port**: 5000
+- **Scheme**: HTTPS
+
+## Resource Requirements
+
+Default resource allocation:
+- **CPU**: 100m request, 500m limit
+- **Memory**: 128Mi request, 512Mi limit
+- **Storage**: 20Gi (configurable)
+
+Adjust these values based on your usage patterns and cluster capacity.
+
+## Monitoring
+
+The cache registry can be monitored through:
+- Registry API endpoints (`/v2/`)
+- Kubernetes deployment and pod metrics
+- Storage usage monitoring
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Pod not starting**: Check if the TLS secret exists
+2. **Storage issues**: Verify PV/PVC configuration and storage availability
+3. **Network connectivity**: Ensure service discovery is working
+
+### Logs
+```bash
+kubectl logs -n <namespace> deployment/cache-registry
+```
+
+### Registry health check
+```bash
+kubectl port-forward -n <namespace> svc/cache-registry-svc 443:443
+curl -k https://localhost:443/v2/
+```
+
+## Disabling the Cache Registry
+
+To disable the cache registry component, set:
+```yaml
+cacheRegistry:
+  enabled: false
+```
+
+Note: This will prevent the creation of all cache registry resources but will not affect the existing Tool Manager functionality. 

--- a/charts/kubiya-runner/examples/cache-registry-values.yaml
+++ b/charts/kubiya-runner/examples/cache-registry-values.yaml
@@ -1,0 +1,80 @@
+# Example configuration for enabling the cache registry component
+# This shows how to configure the Docker registry that caches tool images
+
+cacheRegistry:
+  enabled: true
+  
+  # Persistent Volume configuration
+  pv:
+    name: "docker-registry-pv"
+    size: "50Gi"  # Adjust size based on your needs
+    reclaimPolicy: "Retain"
+    # Use hostPath for local development/testing
+    hostPath: "/var/lib/registry"
+    # For production, consider using a storage class
+    # storageClass: "fast-ssd"
+  
+  # Persistent Volume Claim configuration
+  pvc:
+    name: "docker-registry-pvc"
+    size: "50Gi"
+    # storageClass: "fast-ssd"  # Optional: specify storage class
+    
+  # Deployment configuration
+  deployment:
+    name: "cache-registry"
+    replicas: 1
+    selector: "cache-registry"
+    image:
+      repository: "registry"
+      tag: "2"
+      pullPolicy: "IfNotPresent"
+    
+    # Resource configuration - adjust based on your load
+    resources:
+      limits:
+        cpu: "1"
+        memory: "1Gi"
+      requests:
+        cpu: "200m"
+        memory: "256Mi"
+    
+    # Health check configuration
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /v2/
+        port: 5000
+        scheme: HTTPS
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /v2/
+        port: 5000
+        scheme: HTTPS
+      initialDelaySeconds: 10
+      periodSeconds: 10
+    
+    # Optional: Add node selector for specific nodes
+    # nodeSelector:
+    #   registry: "true"
+    
+    # Optional: Add affinity rules
+    # affinity:
+    #   nodeAffinity:
+    #     requiredDuringSchedulingIgnoredDuringExecution:
+    #       nodeSelectorTerms:
+    #       - matchExpressions:
+    #         - key: "node-role.kubernetes.io/worker"
+    #           operator: In
+    #           values: ["true"]
+  
+  # Service configuration
+  service:
+    name: "cache-registry-svc"
+    type: "ClusterIP"
+    port: 443
+    targetPort: 5000 

--- a/charts/kubiya-runner/templates/_helpers.tpl
+++ b/charts/kubiya-runner/templates/_helpers.tpl
@@ -148,6 +148,21 @@ Kubiya Operator Selector labels
 app.kubernetes.io/kubiya-runner-component: image-updater
 {{- end }}
 
+{{/*
+Cache Registry labels
+*/}}
+{{- define "cache-registry.labels" }}
+{{ include "kubiya-runner-common.labels" . }}
+app.kubernetes.io/kubiya-runner-component: cache-registry
+{{- end }}
+
+{{/*
+Cache Registry Selector labels
+*/}}
+{{- define "cache-registry.selectorLabels" }}
+{{ include "kubiya-runner-common.selectorLabels" . }}
+app.kubernetes.io/kubiya-runner-component: cache-registry
+{{- end }}
 
 # Service Accounts names for all kubiya runner components.
 # If create is set to true, name of the service account is value of .name, or, if .name not provided will be set to component name.

--- a/charts/kubiya-runner/templates/components/cache-registry/cache-registry-deployment.yaml
+++ b/charts/kubiya-runner/templates/components/cache-registry/cache-registry-deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.cacheRegistry.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.cacheRegistry.deployment.name | default "cache-registry" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cache-registry.labels" . | nindent 4 }}
+    app.kubernetes.io/name: cache-registry
+    app.kubernetes.io/component: registry
+spec:
+  replicas: {{ .Values.cacheRegistry.deployment.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ .Values.cacheRegistry.deployment.selector | default "cache-registry" }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.cacheRegistry.deployment.selector | default "cache-registry" }}
+        {{- include "cache-registry.labels" . | nindent 8 }}
+        app.kubernetes.io/name: cache-registry
+        app.kubernetes.io/component: registry
+    spec:
+      {{- with .Values.cacheRegistry.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cacheRegistry.deployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: registry
+          image: {{ .Values.cacheRegistry.deployment.image.repository | default "registry" }}:{{ .Values.cacheRegistry.deployment.image.tag | default "2" }}
+          imagePullPolicy: {{ .Values.cacheRegistry.deployment.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - containerPort: 5000
+              protocol: TCP
+          env:
+            - name: REGISTRY_HTTP_ADDR
+              value: "0.0.0.0:5000"
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: "/certs/tls.crt"
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: "/certs/tls.key"
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "true"
+            {{- with .Values.cacheRegistry.deployment.env }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | quote }}
+              value: {{ tpl $value $ | quote }}
+            {{- end }}
+            {{- end }}
+          volumeMounts:
+            - name: registry-storage
+              mountPath: /var/lib/registry
+            - name: registry-cert
+              mountPath: /certs
+            {{- with .Values.cacheRegistry.deployment.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.cacheRegistry.deployment.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.cacheRegistry.deployment.livenessProbe.enabled }}
+          livenessProbe:
+            {{- omit .Values.cacheRegistry.deployment.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.cacheRegistry.deployment.readinessProbe.enabled }}
+          readinessProbe:
+            {{- omit .Values.cacheRegistry.deployment.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: registry-storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.cacheRegistry.pvc.name | default "docker-registry-pvc" }}
+        - name: registry-cert
+          secret:
+            secretName: {{ .Values.cacheRegistry.deployment.tlsSecretName | default "registry-tls-secret" }}
+        {{- with .Values.cacheRegistry.deployment.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }} 

--- a/charts/kubiya-runner/templates/components/cache-registry/cache-registry-pv.yaml
+++ b/charts/kubiya-runner/templates/components/cache-registry/cache-registry-pv.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.cacheRegistry.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.cacheRegistry.pv.name | default "docker-registry-pv" }}
+  labels:
+    {{- include "cache-registry.labels" . | nindent 4 }}
+    app.kubernetes.io/name: cache-registry
+    app.kubernetes.io/component: registry
+spec:
+  capacity:
+    storage: {{ .Values.cacheRegistry.pv.size | default "20Gi" }}
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: {{ .Values.cacheRegistry.pv.reclaimPolicy | default "Retain" }}
+  {{- if .Values.cacheRegistry.pv.storageClass }}
+  storageClassName: {{ .Values.cacheRegistry.pv.storageClass }}
+  {{- end }}
+  {{- if .Values.cacheRegistry.pv.hostPath }}
+  hostPath:
+    path: {{ .Values.cacheRegistry.pv.hostPath }}
+  {{- else }}
+  {{- with .Values.cacheRegistry.pv.volumeSource }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
+{{- end }} 

--- a/charts/kubiya-runner/templates/components/cache-registry/cache-registry-pvc.yaml
+++ b/charts/kubiya-runner/templates/components/cache-registry/cache-registry-pvc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.cacheRegistry.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.cacheRegistry.pvc.name | default "docker-registry-pvc" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cache-registry.labels" . | nindent 4 }}
+    app.kubernetes.io/name: cache-registry
+    app.kubernetes.io/component: registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.cacheRegistry.pvc.size | default "20Gi" }}
+  {{- if .Values.cacheRegistry.pvc.storageClass }}
+  storageClassName: {{ .Values.cacheRegistry.pvc.storageClass }}
+  {{- end }}
+  {{- if .Values.cacheRegistry.pvc.volumeName }}
+  volumeName: {{ .Values.cacheRegistry.pvc.volumeName }}
+  {{- end }}
+{{- end }} 

--- a/charts/kubiya-runner/templates/components/cache-registry/cache-registry-service.yaml
+++ b/charts/kubiya-runner/templates/components/cache-registry/cache-registry-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.cacheRegistry.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.cacheRegistry.service.name | default "cache-registry-svc" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cache-registry.labels" . | nindent 4 }}
+    app.kubernetes.io/name: cache-registry
+    app.kubernetes.io/component: registry
+spec:
+  type: {{ .Values.cacheRegistry.service.type | default "ClusterIP" }}
+  selector:
+    app: {{ .Values.cacheRegistry.deployment.selector | default "cache-registry" }}
+  ports:
+    - name: https
+      protocol: TCP
+      port: {{ .Values.cacheRegistry.service.port | default 443 }}
+      targetPort: {{ .Values.cacheRegistry.service.targetPort | default 5000 }}
+    {{- with .Values.cacheRegistry.service.additionalPorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }} 

--- a/charts/kubiya-runner/values.yaml
+++ b/charts/kubiya-runner/values.yaml
@@ -261,6 +261,88 @@ toolManager:
         name: nats-creds-volume
       - mountPath: /tmp/kubiya_shared_tools
         name: shared-volume
+# Cache Registry component config - Docker registry for caching tool images
+cacheRegistry:
+  enabled: true
+  # PersistentVolume configuration
+  pv:
+    name: "docker-registry-pv"
+    size: "20Gi"
+    reclaimPolicy: "Retain"
+    # For hostPath storage (default for local development)
+    hostPath: "/var/lib/registry"
+    # Alternatively, use storageClass for dynamic provisioning
+    # storageClass: "standard"
+    # Or provide custom volumeSource configuration
+    # volumeSource:
+    #   nfs:
+    #     server: "nfs-server.example.com"
+    #     path: "/path/to/registry"
+  # PersistentVolumeClaim configuration  
+  pvc:
+    name: "docker-registry-pvc"
+    size: "20Gi"
+    # Optional: specify storage class for dynamic provisioning
+    # storageClass: "standard"
+    # Optional: bind to specific PV
+    # volumeName: "docker-registry-pv"
+  # Deployment configuration
+  deployment:
+    name: "cache-registry"
+    replicas: 1
+    selector: "cache-registry"
+    image:
+      repository: "registry"
+      tag: "2"
+      pullPolicy: "IfNotPresent"
+    # TLS secret name for registry certificates
+    tlsSecretName: "registry-tls-secret"
+    # Node selector for deployment
+    nodeSelector: {}
+    # Affinity settings
+    affinity: {}
+    # Additional environment variables
+    env: {}
+    # Additional volume mounts
+    volumeMounts: []
+    # Additional volumes
+    volumes: []
+    # Resource limits and requests
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+    # Liveness probe configuration
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /v2/
+        port: 5000
+        scheme: HTTPS
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+    # Readiness probe configuration
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /v2/
+        port: 5000
+        scheme: HTTPS
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+  # Service configuration
+  service:
+    name: "cache-registry-svc"
+    type: "ClusterIP"
+    port: 443
+    targetPort: 5000
+    # Additional service ports
+    additionalPorts: []
 # Kubiya workflow engine component config
 workflowEngine:
   replicas: 1


### PR DESCRIPTION
Add cache registry as standalone component - Convert tool-manager programmatic cache registry resources to Helm templates - Create cache-registry as top-level component separate from toolManager - Add 4 Kubernetes resources: PV, PVC, Deployment, Service - Include comprehensive configuration options for storage, resources, health checks - Add example values and documentation - Bump chart version to 0.7.0 for new component addition" 
[DEV-1188-story-deploy-registry-via-runners-helm-chart d57438a] DEV-1188: Add cache registry as standalone component - Convert tool-manager programmatic cache registry resources to Helm templates - Create cache-registry as top-level component separate from toolManager - Add 4 Kubernetes resources: PV, PVC, Deployment, Service - Include comprehensive configuration options for storage, resources, health checks - Add example values and documentation - Bump chart version to 0.7.0 for new component addition